### PR TITLE
Fix collector registration. Fix unit tests.

### DIFF
--- a/master.js
+++ b/master.js
@@ -347,7 +347,7 @@ class AlAzureMaster {
                     
                     var regBody = Object.assign(
                             master.getConfigAttrs(),
-                            master.getAzureCreds,
+                            master.getAzureCreds(),
                             registerOpts);
                     master._azcollectc.register(regBody)
                         .then(resp => {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "al-collector-js": "git://github.com/alertlogic/al-collector-js#master",
-    "async": "*",
+    "async": "^2.6.1",
     "azure": "^2.3.1-preview",
     "parse-key-value": "^1.0.0",
     "path": "^0.12.7"

--- a/test/master_test.js
+++ b/test/master_test.js
@@ -122,6 +122,15 @@ describe('Master tests', function() {
             assert.equal(process.env.APP_AZCOLLECT_ENDPOINT, 'new-azcollect-endpoint');
             assert.equal(collectorHostId, 'new-host-id');
             assert.equal(collectorSourceId, 'new-source-id');
+            const expectedRegisterBody = {
+                body: {
+                    app_tenant_id: "tenant-id",
+                    client_id: "client-id",
+                    client_secret: "client-secret",
+                    version: "1.0.0"
+                }
+            };
+            sinon.assert.calledWith(fakePost, '/azure/ehub/subscription-id/kktest11-rg/kktest11-name', expectedRegisterBody);
             done();
         });
     });
@@ -273,10 +282,7 @@ describe('Master tests', function() {
             const expectedCheckin = { 
                 body: {
                     version: '1.0.0',
-                    web_app_name: 'kktest11-name',
-                    app_resource_group: 'kktest11-rg',
                     app_tenant_id: 'tenant-id',
-                    subscription_id: 'subscription-id',
                     host_id: 'existing-host-id',
                     source_id: 'existing-source-id',
                     statistics: [{ 'Master': { 'errors': 0, 'invocations': 2 } }, { 'Collector': { 'errors': 1, 'invocations': 10 } }, { 'Updater': { 'errors': 0, 'invocations': 0 } }],
@@ -343,10 +349,7 @@ describe('Master tests', function() {
             const expectedCheckin = { 
                 body: {
                     version: '1.0.0',
-                    web_app_name: 'kktest11-name',
-                    app_resource_group: 'kktest11-rg',
                     app_tenant_id: 'tenant-id',
-                    subscription_id: 'subscription-id',
                     host_id: 'existing-host-id',
                     source_id: 'existing-source-id',
                     statistics: [{ 'Master': { 'errors': 0, 'invocations': 2 } }, { 'Collector': { 'errors': 1, 'invocations': 10 } }, { 'Updater': { 'errors': 0, 'invocations': 0 } }],


### PR DESCRIPTION
### Problem Description
Collector fails to register due to missing credentials in the registration request.

### Solution Description
Fix the typo in master registration.
Fix unit tests according to recent changes in https://github.com/alertlogic/al-collector-js/pull/16.

