### PR TITLE
Add collection stats fun implementation.

### DIFF
--- a/master.js
+++ b/master.js
@@ -47,9 +47,8 @@ const DEFAULT_APP_FUNCTIONS = ['Master', 'Collector', 'Updater'];
  * In case of health-check succeeds a custom health check function should call callback(null), otherwise return an error object constructed with a help of.
  * errorStatusFmt() function. For example, master.errorStatusFmt('ALAZU00001', 'Some error description');
  * 
- * @param {Array.<Function>} statsFuns - (optional) list of custom stats functions (can be just empty, so only common are applied). Default is [].
- * @param {Array.<String>} collectorAzureFuns - (optional) the list of Azure function names a collector Web application consists of. Default is ['Master', 'Collector', 'Updater'].
- * 
+ * @param {Array.<Function>} collectionStatsFun - (optional) a function which is called during checking to get collection stats. The result of the function will be assigned to 'collection_stats' property of a checkin body. Default is null.
+ * @
  * @param {Object} alOptional - optional Alert Logic service parameters.
  * @param {String} [alOptional.hostId] - (optional) Alert Logic collector host id. Default is process.env.COLLECTOR_HOST_ID
  * @param {String} [alOptional.sourceId] - (optional) Alert Logic collector source id. Default is process.env.COLLECTOR_SOURCE_ID
@@ -67,18 +66,22 @@ const DEFAULT_APP_FUNCTIONS = ['Master', 'Collector', 'Updater'];
  * @param {String} [azureOptional.resourceGroup] - (optional) Azure resource group where the function is deployed. Default is process.env.APP_RESOURCE_GROUP
  * @param {String} [azureOptional.webAppName] - (optional) Azure web application name Update is running for. Default is process.env.WEBSITE_SITE_NAME
  * 
- * @param {List} collectorAzureFuns - (optional) a list of Azure function names a collector consists of. Default is ['Master', 'Collector', 'Updater']
+ * @param {Array.<String>} collectorAzureFunNames - (optional) the list of Azure function names a collector Web application consists of. Default is ['Master', 'Collector', 'Updater'].
+ * 
  */
 class AlAzureMaster {
-    constructor(azureContext, collectorType, version, healthCheckFuns, statsFuns,
+    constructor(azureContext, collectorType, version, healthCheckFuns, collectionStatsFun,
             {hostId, sourceId, aimsKeyId, aimsKeySecret, alApiEndpoint, alAzcollectEndpoint, alDataResidency} = {},
             {clientId, domain, clientSecret, subscriptionId, resourceGroup, webAppName} = {},
-            collectorAzureFuns = DEFAULT_APP_FUNCTIONS) {
+            collectorAzureFunNames = DEFAULT_APP_FUNCTIONS) {
         this._azureContext = azureContext;
         this._collectorType = collectorType;
         this._version = version;
         this._customHealthChecks = healthCheckFuns ? healthCheckFuns : [];
-        this._customStatsFuns = statsFuns ? statsFuns : [];
+        this._collectionStatsFun = collectionStatsFun && typeof collectionStatsFun === 'function' ? collectionStatsFun :
+            function(m, ts, callback) {
+                return callback();
+        };
         
         // Init Alert Logic optional configuration parameters
         this._hostId = hostId ? hostId : process.env.COLLECTOR_HOST_ID;
@@ -124,7 +127,7 @@ class AlAzureMaster {
             { 'tokenCache': tokenCache });
                 
         this._azureWebsiteClient = new azureArmWebsite(this._azureCreds, this._subscriptionId);
-        this._appStats = new AzureWebAppStats(collectorAzureFuns);
+        this._appStats = new AzureWebAppStats(collectorAzureFunNames);
     }
     
     getApplicationTokenCredentials(){
@@ -303,23 +306,25 @@ class AlAzureMaster {
         });
     }
     
-    _getCustomStatsFuns(timestamp) {
-        var master = this;
-        return master._customStatsFuns.map(function(check) {
-            return async.reflect(function(callback) {
-                return check(master, timestamp, callback);
-            });
-        });
-    }
-    
     getStats(timestamp, callback) {
         var master = this;
         
         async.parallel([
             async.reflect(function(callback) {
                 return master._appStats.getAppStats(timestamp, callback);
+            }),
+            async.reflect(function(callback) {
+                return master._collectionStatsFun(master, timestamp, function(err, stats) {
+                    var result;
+                    if (stats && typeof stats === 'object') {
+                        result = {collection_stats: stats};
+                    } else {
+                        result = null;
+                    }
+                    return callback(err, result);
+                });
             })
-        ].concat(master._getCustomStatsFuns()),
+        ],
         function(err, results){
             const statValues = results.reduce(function(acc, val){
                 if (val.error) {

--- a/test/master_test.js
+++ b/test/master_test.js
@@ -277,13 +277,13 @@ describe('Master tests', function() {
             nock('https://login.microsoftonline.com:443', {'encodedQueryParams':true})
             .post(/token$/, /.*/ )
             .query(true)
-            .times(5)
+            .times(100)
             .reply(200, mock.AZURE_TOKEN_MOCK);
             
             nock('https://management.azure.com:443', {'encodedQueryParams':true})
             .get(/kktest11-name$/, /.*/ )
             .query(true)
-            .times(2)
+            .times(100)
             .reply(200, mock.getAzureWebApp());
             
             // Mock Alert Logic HTTP calls
@@ -320,8 +320,12 @@ describe('Master tests', function() {
             
         });
         
-        afterEach(function() {
+        afterEach(function(done) {
             fakeStats.restore();
+            fakePost.resetHistory();
+            fs.unlink(mock.AL_TOKEN_CACHE_FILENAME, function(err){
+                done();
+            });
         });
         
         it('Verify checkin ok', function(done) {
@@ -352,7 +356,7 @@ describe('Master tests', function() {
             nock('https://management.azure.com:443', {'encodedQueryParams':true})
             .get(/stats-error-name$/, /.*/ )
             .query(true)
-            .times(2)
+            .times(1)
             .reply(200, mock.getAzureWebApp('Limited'));
             
             process.env.WEBSITE_SITE_NAME = 'stats-error-name';
@@ -402,7 +406,6 @@ describe('Master tests', function() {
                     }
                 };
                 const expectedUrl = '/azure/ehub/checkin/subscription-id/kktest11-rg/kktest11-name';
-                fakeStats.restore();
                 sinon.assert.calledWith(fakePost, expectedUrl, expectedCheckin);
                 done();
             });
@@ -433,7 +436,52 @@ describe('Master tests', function() {
                     }
                 };
                 const expectedUrl = '/azure/ehub/checkin/subscription-id/kktest11-rg/kktest11-name';
-                fakeStats.restore();
+                sinon.assert.calledWith(fakePost, expectedUrl, expectedCheckin);
+                done();
+            });
+        });
+        
+        it('Verify checkin with custom stats fun', function(done) {
+            var customStatsFuns = [
+                function(m, t, callback) {
+                    const stats = {
+                        collection_stats: {
+                            events: 5,
+                            bytes: 10
+                        }
+                    };
+                    return callback(null, stats);
+                },
+                function(m, t, callback) {
+                    return callback(m.errorStatusFmt('ALAZU000004', 'Custom Error'));
+                },
+                function(m, t, callback) {
+                    const stats = {
+                        other_stats: {
+                            foo: 1,
+                            bar: 2
+                        }
+                    };
+                    return callback(null, stats);
+                },
+            ];
+            var master = new AlAzureMaster(mock.DEFAULT_FUNCTION_CONTEXT, 'ehub', '1.0.0', null, customStatsFuns);
+            master.checkin('2017-12-22T14:31:39', function(err){
+                if (err) console.log(err);
+                const expectedCheckin = { 
+                    body: {
+                        version: '1.0.0',
+                        app_tenant_id: 'tenant-id',
+                        host_id: 'existing-host-id',
+                        source_id: 'existing-source-id',
+                        statistics: [{ 'Master': { 'errors': 0, 'invocations': 2 } }, { 'Collector': { 'errors': 1, 'invocations': 10 } }, { 'Updater': { 'errors': 0, 'invocations': 0 } }],
+                        status: 'ok',
+                        details: [],
+                        collection_stats: { events: 5, bytes: 10 },
+                        other_stats: { foo: 1, bar: 2 }
+                    }
+                };
+                const expectedUrl = '/azure/ehub/checkin/subscription-id/kktest11-rg/kktest11-name';
                 sinon.assert.calledWith(fakePost, expectedUrl, expectedCheckin);
                 done();
             });


### PR DESCRIPTION
### Solution Description
Implement collection stats functionality, replacing `customStatsFuns` array. 
Now a collector can provide a callback function for collection stats retrieval. The callback is called every `Master` checkin. The results of this function are assigned to `collection_stats` property of the `Master` checkin request body.