### PR TITLE
Do not include DL blob stats into checkin if DL container is not found.

### DIFF
--- a/dlblob.js
+++ b/dlblob.js
@@ -64,7 +64,7 @@ class AlAzureDlBlob {
     }
     
     /**
-     *  @function Retrievs the first page (5000) of dead letter blobs and finds the one with the maximum size.
+     *  @function Retrieves the first page (5000) of dead letter blobs and finds the one with the maximum size.
      *  
      *  @param callback
      *  @returns callback

--- a/master.js
+++ b/master.js
@@ -335,7 +335,7 @@ class AlAzureMaster {
             }),
             async.reflect(function(callback) {
                 return master._alAzureDlBlob.getDlBlobStats(function(err, dlstats) {
-                    if (err && err.statusCode === 404) {
+                    if (err && err.statusCode === 404 && !process.env.APP_DL_CONTAINER_NAME) {
                         return callback(null, {});
                     } else {
                         return callback(err, dlstats);

--- a/master.js
+++ b/master.js
@@ -334,13 +334,11 @@ class AlAzureMaster {
                 });
             }),
             async.reflect(function(callback) {
-                return master._alAzureDlBlob.getDlBlobStats(function(err, dlstats) {
-                    if (err && err.statusCode === 404 && !process.env.APP_DL_CONTAINER_NAME) {
-                        return callback(null, {});
-                    } else {
-                        return callback(err, dlstats);
-                    }
-                });
+                if (process.env.APP_DL_CONTAINER_NAME) {
+                    return master._alAzureDlBlob.getDlBlobStats(callback);
+                } else {
+                    return callback(null, {});
+                }
             })
         ],
         function(err, results){

--- a/master.js
+++ b/master.js
@@ -334,7 +334,13 @@ class AlAzureMaster {
                 });
             }),
             async.reflect(function(callback) {
-                return master._alAzureDlBlob.getDlBlobStats(callback);
+                return master._alAzureDlBlob.getDlBlobStats(function(err, dlstats) {
+                    if (err && err.statusCode === 404) {
+                        return callback(null, {});
+                    } else {
+                        return callback(err, dlstats);
+                    }
+                });
             })
         ],
         function(err, results){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-azure-collector-js",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Alert Logic Azure Collector Common Library",
   "license": "MIT",
   "repository": {

--- a/test/master_test.js
+++ b/test/master_test.js
@@ -460,6 +460,7 @@ describe('Master tests', function() {
             const storedDlName = process.env.APP_DL_CONTAINER_NAME;
             delete process.env.APP_DL_CONTAINER_NAME;
             
+            // This should not be called
             nock('https://testappo365.blob.core.windows.net:443', {'encodedQueryParams':true})
             .get('/alertlogic-dl')
             .query(true)

--- a/test/master_test.js
+++ b/test/master_test.js
@@ -383,7 +383,7 @@ describe('Master tests', function() {
             
             // List blobs
             nock('https://testappo365.blob.core.windows.net:443', {'encodedQueryParams':true})
-            .get('/alertlogic-dl-test')
+            .get('/alertlogic-dl')
             .query(true)
             .times(5)
             .reply(200, mock.LIST_CONTAINER_BLOBS());
@@ -410,7 +410,7 @@ describe('Master tests', function() {
             process.env.APP_AZCOLLECT_ENDPOINT = 'existing-azcollect-endpoint';
             process.env.COLLECTOR_HOST_ID = 'existing-host-id';
             process.env.COLLECTOR_SOURCE_ID = 'existing-source-id';
-            process.env.APP_DL_CONTAINER_NAME = 'alertlogic-dl-test';
+            process.env.APP_DL_CONTAINER_NAME = 'alertlogic-dl';
             
             // Expected Azure parameters
             process.env.WEBSITE_SITE_NAME = 'kktest11-name';

--- a/test/master_test.js
+++ b/test/master_test.js
@@ -383,7 +383,7 @@ describe('Master tests', function() {
             
             // List blobs
             nock('https://testappo365.blob.core.windows.net:443', {'encodedQueryParams':true})
-            .get('/alertlogic-dl')
+            .get('/alertlogic-dl-test')
             .query(true)
             .times(5)
             .reply(200, mock.LIST_CONTAINER_BLOBS());
@@ -410,7 +410,7 @@ describe('Master tests', function() {
             process.env.APP_AZCOLLECT_ENDPOINT = 'existing-azcollect-endpoint';
             process.env.COLLECTOR_HOST_ID = 'existing-host-id';
             process.env.COLLECTOR_SOURCE_ID = 'existing-source-id';
-            process.env.APP_DL_CONTAINER_NAME = 'alertlogic-dl';
+            process.env.APP_DL_CONTAINER_NAME = 'alertlogic-dl-test';
             
             // Expected Azure parameters
             process.env.WEBSITE_SITE_NAME = 'kktest11-name';
@@ -457,9 +457,11 @@ describe('Master tests', function() {
         });
         
         it('Verify checkin ok, no DL stats', function(done) {
-            process.env.APP_DL_CONTAINER_NAME = 'alertlogic-dl-test';
+            const storedDlName = process.env.APP_DL_CONTAINER_NAME;
+            delete process.env.APP_DL_CONTAINER_NAME;
+            
             nock('https://testappo365.blob.core.windows.net:443', {'encodedQueryParams':true})
-            .get('/alertlogic-dl-test')
+            .get('/alertlogic-dl')
             .query(true)
             .times(5)
             .reply(404, mock.CONTAINER_NOT_FOUND);
@@ -467,6 +469,7 @@ describe('Master tests', function() {
             var master = new AlAzureMaster(mock.DEFAULT_FUNCTION_CONTEXT, 'ehub', '1.0.0');
             master.checkin('2017-12-22T14:31:39', function(err, resp){
                 if (err) console.log(err);
+                process.env.APP_DL_CONTAINER_NAME = storedDlName;
                 let cs = new CollectionStatRecord();
                 cs.log.bytes = 10;
                 cs.log.events = 15;

--- a/test/master_test.js
+++ b/test/master_test.js
@@ -15,6 +15,7 @@ const alcollector = require('@alertlogic/al-collector-js');
 
 const AlAzureMaster = require('../master').AlAzureMaster;
 const AzureWebAppStats = require('../appstats').AzureWebAppStats;
+const CollectionStatRecord = require('../appstats').CollectionStatRecord;
 const mock = require('./mock');
 
 describe('Master tests', function() {
@@ -450,6 +451,42 @@ describe('Master tests', function() {
                 const expectedUrl = '/azure/ehub/checkin/subscription-id/kktest11-rg/kktest11-name';
                 fakeStats.restore();
                 sinon.assert.calledWithMatch(fakePost, expectedUrl, expectedCheckin);
+                assert.equal(resp, mock.CHECKIN_RESPONSE_OK);
+                done();
+            });
+        });
+        
+        it('Verify checkin ok, no DL stats', function(done) {
+            process.env.APP_DL_CONTAINER_NAME = 'alertlogic-dl-test';
+            nock('https://testappo365.blob.core.windows.net:443', {'encodedQueryParams':true})
+            .get('/alertlogic-dl-test')
+            .query(true)
+            .times(5)
+            .reply(404, mock.CONTAINER_NOT_FOUND);
+            
+            var master = new AlAzureMaster(mock.DEFAULT_FUNCTION_CONTEXT, 'ehub', '1.0.0');
+            master.checkin('2017-12-22T14:31:39', function(err, resp){
+                if (err) console.log(err);
+                let cs = new CollectionStatRecord();
+                cs.log.bytes = 10;
+                cs.log.events = 15;
+                const expectedCheckin = { 
+                    body: {
+                        version: '1.0.0',
+                        app_tenant_id: 'tenant-id',
+                        collection_stats: cs,
+                        host_id: 'existing-host-id',
+                        source_id: 'existing-source-id',
+                        statistics: [{ 'Master': { 'errors': 0, 'invocations': 2 } }, { 'Collector': { 'errors': 1, 'invocations': 10 } }, { 'Updater': { 'errors': 0, 'invocations': 0 } }],
+                        // No DL stats
+                        //dl_stats: { dl_count: 6, max_dl_size: 4257 },
+                        status: 'ok',
+                        details: []
+                    }
+                };
+                const expectedUrl = '/azure/ehub/checkin/subscription-id/kktest11-rg/kktest11-name';
+                fakeStats.restore();
+                sinon.assert.calledWith(fakePost, expectedUrl, expectedCheckin);
                 assert.equal(resp, mock.CHECKIN_RESPONSE_OK);
                 done();
             });


### PR DESCRIPTION
### Problem Description
Some collectors may not have blob container for dead letter blobs and should not report error status during checkin.

### Solution Description
Do not report DL stats at checkin if DL container is not set in application env (`process.env.APP_DL_CONTAINER_NAME`) and DL container doesn't exist.
