### PR TITLE
fix error handling to catch raw string errors

### DIFF
--- a/master.js
+++ b/master.js
@@ -367,12 +367,7 @@ class AlAzureMaster {
             if (errStatus) {
                 if(typeof errStatus === 'string'){
                     master._azureContext.log.warn('Health check failed with: ',  errStatus);
-                    status = {
-                        status: 'error',
-                        details: [ errStatus ],
-                        // Set error code to code for custom health check error
-                        error_code: 'ALAZU000004'
-                    };
+                    status = master.errorStatusFmt('ALAZU000004', errStatus);
                 } else {
                     master._azureContext.log.warn('Health check failed with',  errStatus.details);
                     status = errStatus;

--- a/master.js
+++ b/master.js
@@ -366,7 +366,16 @@ class AlAzureMaster {
             var status;
             if (errStatus) {
                 master._azureContext.log.warn('Health check failed with',  errStatus.details);
-                status = errStatus;
+                if(typeof errStatus === 'string'){
+                    status = {
+                        status: 'error',
+                        details: [ errStatus ],
+                        // Set error code to code for custom health check error
+                        error_code: 'ALAZU000004'
+                    };
+                } else {
+                    status = errStatus;
+                }
             } else {
                 status = {
                     status: 'ok',

--- a/master.js
+++ b/master.js
@@ -365,8 +365,8 @@ class AlAzureMaster {
         function(errStatus) {
             var status;
             if (errStatus) {
-                master._azureContext.log.warn('Health check failed with',  errStatus.details);
                 if(typeof errStatus === 'string'){
+                    master._azureContext.log.warn('Health check failed with: ',  errStatus);
                     status = {
                         status: 'error',
                         details: [ errStatus ],
@@ -374,6 +374,7 @@ class AlAzureMaster {
                         error_code: 'ALAZU000004'
                     };
                 } else {
+                    master._azureContext.log.warn('Health check failed with',  errStatus.details);
                     status = errStatus;
                 }
             } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-azure-collector-js",
-  "version": "1.1.3",
+  "version": "1.2.3",
   "description": "Alert Logic Azure Collector Common Library",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-azure-collector-js",
-  "version": "1.2.3",
+  "version": "1.2.0",
   "description": "Alert Logic Azure Collector Common Library",
   "license": "MIT",
   "repository": {
@@ -28,7 +28,7 @@
     "sinon": "^7.2.3"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^1.1.2",
+    "@alertlogic/al-collector-js": "^1.3.0",
     "async": "^2.6.1",
     "azure": "^2.3.1-preview",
     "parse-key-value": "^1.0.0",

--- a/test/collector_test.js
+++ b/test/collector_test.js
@@ -64,8 +64,8 @@ describe('Collector tests', function() {
         
         fakePost = sinon.stub(alcollector.AlServiceC.prototype, 'post').callsFake(
             function fakeFn(path, extraOptions) {
-                assert.equal(extraOptions.headers['Content-Type'], 'alertlogic.com/pass-through');
-                assert.equal(path, '/data/aicspmsgs');
+                assert.equal(extraOptions.headers['Content-Type'], 'alertlogic.com/lm3-protobuf');
+                assert.equal(path, '/data/logmsgs');
                 assert.equal(expectedBody, extraOptions.body.toString('base64'));
                 
                 return new Promise(function(resolve, reject){
@@ -106,8 +106,8 @@ describe('Collector tests', function() {
         
         fakePost = sinon.stub(alcollector.AlServiceC.prototype, 'post').callsFake(
             function fakeFn(path, extraOptions) {
-                assert.equal(extraOptions.headers['Content-Type'], 'alertlogic.com/pass-through');
-                assert.equal(path, '/data/aicspmsgs');
+                assert.equal(extraOptions.headers['Content-Type'], 'alertlogic.com/lm3-protobuf');
+                assert.equal(path, '/data/logmsgs');
                 assert.equal(expectedBody, extraOptions.body.toString('base64'));
                 
                 return new Promise(function(resolve, reject){


### PR DESCRIPTION
### Problem Description
There were custom health check that were returning raw string errors to the collector, and these were being spread in to the checking body. causing bad checkin bodies that were throwing errrors in azcollect

### Solution Description
check for raw string errors and wrap them in the proper error object.

