### PR TITLE
Limit invocations stats retrieval

### DIFF
--- a/appstats.js
+++ b/appstats.js
@@ -88,7 +88,7 @@ class AzureWebAppStats {
         };
         let initialToken = {
             token: null,
-            page: 0
+            pageNum: 0
         };
         return this._getFunctionStatsAcc(functionName, timestamp, initialToken, accStats, callback);
     };
@@ -109,10 +109,10 @@ class AzureWebAppStats {
                     };
                     return callback(null, obj);
                 } else {
-                    if (result.continuationToken && contToken.page < MAX_STATS_PAGES) {
+                    if (result.continuationToken && contToken.pageNum < MAX_STATS_PAGES) {
                         let cont = {
                             token: result.continuationToken,
-                            page: contToken.page + 1
+                            pageNum: contToken.pageNum + 1
                         };
 
                         return appstats._getFunctionStatsAcc(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-azure-collector-js",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Alert Logic Azure Collector Common Library",
   "license": "MIT",
   "repository": {

--- a/test/mock.js
+++ b/test/mock.js
@@ -246,6 +246,24 @@ var COLLECTOR_INVOCATION_LOGS = {
     ]
 };
 
+var COLLECTOR_INVOCATION_LOGS_CONTD = {
+    entries : [
+      { PartitionKey: { '$': 'Edm.String', _: 'I' },
+        RowKey: { '$': 'Edm.String', _: '1bcef7c9-e0c3-4728-a704-b2b4c6e0f375' },
+        Timestamp: { '$': 'Edm.DateTime', _: '2017-12-22T10:05:30.666Z' },
+        ArgumentsJson: { _: '{"req":"Method: POST, Uri: https://test.azurewebsites.net/api/o365/webhook","_log":null,"_binder":null,"_context":"1bcef7c9-e0c3-4728-a704-b2b4c6e0f375","_logger":null,"$return":"response"}' },
+        EndTime: { '$': 'Edm.DateTime', _: '2017-12-22T10:04:47.760Z' },
+        FunctionInstanceHeartbeatExpiry: { '$': 'Edm.DateTime', _: '2017-12-22T10:07:45.676Z' },
+        FunctionName: { _: 'O365WebHook' },
+        LogOutput: { _: '' },
+        StartTime: { '$': 'Edm.DateTime', _: '2017-12-22T10:04:47.760Z' },
+        TriggerReason: { _: 'This function was programmatically called via the host APIs.' },
+        '.metadata': { etag: 'W/"datetime\'2017-12-22T10%3A05%3A30.6667953Z\'"' }
+      }
+    ],
+    continuationToken: 'cont-token'
+};
+
 var COLLECTOR_INVOCATION_FILTERJSON_LOGS = [
   { PartitionKey: { '$': 'Edm.String', _: 'I' },
     RowKey: { '$': 'Edm.String', _: '1bcef7c9-e0c3-4728-a704-b2b4c6e0f375' },
@@ -516,6 +534,7 @@ module.exports = {
     DEFAULT_FUNCTION_CONTEXT: DEFAULT_FUNCTION_CONTEXT,
     INVOCATION_STATS: INVOCATION_STATS,
     COLLECTOR_INVOCATION_LOGS: COLLECTOR_INVOCATION_LOGS,
+    COLLECTOR_INVOCATION_LOGS_CONTD: COLLECTOR_INVOCATION_LOGS_CONTD,
     COLLECTOR_INVOCATION_FILTERJSON_LOGS: COLLECTOR_INVOCATION_FILTERJSON_LOGS,
     MASTER_INVOCATION_LOGS: MASTER_INVOCATION_LOGS,
     UPDATER_INVOCATION_LOGS: UPDATER_INVOCATION_LOGS,


### PR DESCRIPTION
### Problem Description
If ehub function is very busy it may take too much time for Master function to retrieve invocation stats meaning that collector highly likely will miss a checkin flapping the status to error.

### Solution Description
Get only first 10 pages of invocation stats.