### PR TITLE
 Checkin failed with error invalid_input, body error in azcollect when sockets exhaust in azure function app while using application insights

### DIFF
--- a/appstats.js
+++ b/appstats.js
@@ -292,8 +292,12 @@ class AzureAppInsightStats extends AzureAppStats {
                 return callback(errMessage, null);
             });
         }).catch((err) => {
-            let errMessage = `An error occurred, while getting application insights appId ${err}`;
-            return callback(errMessage, null);
+            if (appstats.invocationsCount.length > 0) {
+                return callback(null, { statistics: appstats.invocationsCount });
+            } else {
+                let errMessage = `An error occurred, while getting application insights appId ${err}`;
+                return callback(errMessage, null);
+            }
         });
 
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-azure-collector-js",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Alert Logic Azure Collector Common Library",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
### Problem Description
 Checkin failed with error invalid_input, body error in azcollect when sockets exhaust in azure function app while using application insights .
 the below error 
 Statistics retrieval failed with An error occurred, while getting application insights appId AggregateAuthenticationError: ChainedTokenCredential authentication failed.
CredentialUnavailableError: EnvironmentCredential is unavailable. No underlying credential could be used. To troubleshoot, visit https://aka.ms/azsdk/js/identity/environmentcredential/troubleshoot.
CredentialUnavailableError: WorkloadIdentityCredential: is unavailable. tenantId, clientId, and federatedTokenFilePath are required parameters. 
  Still, this doesn’t address the root cause of the issue which is the intermittent EACCES errors.
### Solution Description
Fixed Checkin failed with error invalid_input, body error in application statistics code  by adding **statistics** field which was not send to checkin payload because of sockets exhaust listing of resource group called failed.

 