### PR TITLE
fix: re-add putLogStats call to populate stats queue

### DIFF
--- a/collector.js
+++ b/collector.js
@@ -11,6 +11,7 @@
 
 const moment = require('moment');
 const alcollector = require('@alertlogic/al-collector-js');
+const AzureCollectionStats = require('./appstats').AzureCollectionStats;
 
 const COLLECTOR_RETRY_OPTS = {
     factor: 2,
@@ -62,6 +63,7 @@ class AlAzureCollector {
         var ingestEndpoint = alIngestEndpoint ? alIngestEndpoint : process.env.APP_INGEST_ENDPOINT;
         this._ingestc = new alcollector.IngestC(ingestEndpoint, aimsc, 'azure_function', COLLECTOR_RETRY_OPTS);
         this._alDataResidency = alDataResidency ? alDataResidency : process.env.CUSTOMCONNSTR_APP_AL_RESIDENCY;
+        this._collectionStats = new AzureCollectionStats(azureContext);
     }
     
     _defaultHostmetaElems() {
@@ -114,6 +116,7 @@ class AlAzureCollector {
         // Somebody can still pass 'undefined' as hostmetaElems and it will be added to args list.
         var hm = hostmetaElems ? hostmetaElems : this._defaultHostmetaElems();
         var ingestc = this._ingestc;
+        var stats = this._collectionStats;
         
         if (messages && messages.length > 0) {
             let buildPayloadObj = {
@@ -131,14 +134,19 @@ class AlAzureCollector {
                 } else {
                     ingestc.sendLogmsgs(data.payload)
                         .then( resp => {
-                            let lmcStats = this._prepareLmcStats(data.raw_count, data.raw_bytes);
-                            ingestc.sendLmcstats(JSON.stringify([lmcStats]))
-                                .then(resp => {
-                                    return callback(null, resp);
-                                })
-                                .catch(exception => {
-                                    return callback(null);
-                                });
+                            stats.putLogStats(data.raw_bytes, data.raw_count, callback).then( resp => {
+                                 let lmcStats = this._prepareLmcStats(data.raw_count, data.raw_bytes);
+                                    ingestc.sendLmcstats(JSON.stringify([lmcStats]))
+                                           .then(resp => {
+                                               return callback(null, resp);
+                                           })
+                                           .catch(exception => {
+                                               return callback(null);
+                                           });
+                            })
+                            .catch(exception => {
+                                return callback(null);
+                            })
                         })
                         .catch( err => {
                             return callback(err);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-azure-collector-js",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "description": "Alert Logic Azure Collector Common Library",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
### Problem Description
In https://github.com/alertlogic/al-azure-collector-js/pull/27, the call to `putLogStats` was removed. This meant that all collectors deployed with this version, or any future version, no longer published their stats to an AzureQueue. For checking in with our backend, we pull stats from this queue to populate the checkin body. The absence of stats in the queue meant that we were always sending 0 bytes/messages collected; some of our monitoring was impacted as a result.

### Solution Description
- Partially revert https://github.com/alertlogic/al-azure-collector-js/pull/27 by adding the call to `putLogStats` back in.

