### PR TITLE
fix: remove .then from putLogStats

### DIFF
--- a/collector.js
+++ b/collector.js
@@ -132,25 +132,26 @@ class AlAzureCollector {
                 if (err) {
                     return callback(err);
                 } else {
-                    ingestc.sendLogmsgs(data.payload)
-                        .then( resp => {
-                            stats.putLogStats(data.raw_bytes, data.raw_count, callback).then( resp => {
-                                 let lmcStats = this._prepareLmcStats(data.raw_count, data.raw_bytes);
-                                    ingestc.sendLmcstats(JSON.stringify([lmcStats]))
-                                           .then(resp => {
-                                               return callback(null, resp);
-                                           })
-                                           .catch(exception => {
-                                               return callback(null);
-                                           });
-                            })
-                            .catch(exception => {
-                                return callback(null);
-                            })
-                        })
-                        .catch( err => {
-                            return callback(err);
-                        });
+                   ingestc.sendLogmsgs(data.payload).then(resp => {
+                       stats.putLogStats(data.raw_bytes, data.raw_count, (err) => {
+                           if (err) {
+                               return callback(err);
+                           }
+
+                           let lmcStats = this._prepareLmcStats(data.raw_count, data.raw_bytes);
+
+                           ingestc.sendLmcstats(JSON.stringify([lmcStats]))
+                                  .then(resp => {
+                                      return callback(null, resp);
+                                  })
+                                  .catch(exception => {
+                                      return callback(null);
+                                  });
+                       });
+                   })
+                          .catch(err => {
+                              return callback(err);
+                          });
                 }
             });
         } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-azure-collector-js",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "description": "Alert Logic Azure Collector Common Library",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
### Problem Description
`stats.putLogStats` does not return a promise, thus using `.then` was incorrect, causing the collector to error out after sending stats.

### Solution Description
Change the call to a normal function call with some error handling

