### PR TITLE
Update nodejs to 22 version and bump al-collector-js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-azure-collector-js",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "description": "Alert Logic Azure Collector Common Library",
   "license": "MIT",
   "repository": {
@@ -29,7 +29,7 @@
     "sinon": "^18.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.14",
+    "@alertlogic/al-collector-js": "3.0.17",
     "@azure/applicationinsights-query": "^1.1.0",
     "@azure/arm-appinsights": "^4.0.0",
     "@azure/arm-appservice": "5.8.0",

--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -8,7 +8,7 @@ stages:
             - pull_request
             - pull_request:
                 trigger_phrase: test it
-        image: node:20
+        image: node:22
         compute_size: small
         commands:
             - make test
@@ -17,7 +17,7 @@ stages:
         name: NPM Push - Publish
         when:
             - push: ['npm']
-        image: node:20
+        image: node:22
         compute_size: small
         commands:
             - make test


### PR DESCRIPTION
### Problem Description
Upgrade node.js 20 to 22 or latest version as node 20 is getting deprecated or EOL in April 30, 2026

### Solution Description
Updated node.js to 22 version as node 20 is getting deprecated or EOL in April 30, 2026

